### PR TITLE
Add option to prevent draining all empty instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Once the draining process is complete, the instance will be terminated.
 * SCALE_IN_CPU_TH = 30 `# Below this EC2 average metric scaling would take action`
 * SCALE_IN_MEM_TH = 60 `# Below this cluster average metric scaling would take action`
 * FUTURE_MEM_TH = 70 `# Below this future metric scaling would take action`
+* DRAIN_ALL_EMPTY_INSTANCES = True `# Set to False to prevent scaling in more than one instance at a time`
 * ECS_AVOID_STR = 'awseb' `# Use this to avoid clusters containing a specific string (i.e ElasticBeanstalk clusters)`
 
 ##### How to create a role to run ecscale:

--- a/ecscale.py
+++ b/ecscale.py
@@ -6,6 +6,7 @@ import os
 SCALE_IN_CPU_TH = 30
 SCALE_IN_MEM_TH = 60
 FUTURE_MEM_TH = 70
+DRAIN_ALL_EMPTY_INSTANCES = True
 ECS_AVOID_STR = 'awseb'
 logline = {}
 
@@ -259,7 +260,7 @@ def main(run='normal'):
         if (clusterMemReservation < FUTURE_MEM_TH and 
            future_reservation(activeContainerDescribed, clusterMemReservation) < FUTURE_MEM_TH): 
         # Future memory levels allow scale
-            if emptyInstances.keys():
+            if DRAIN_ALL_EMPTY_INSTANCES and emptyInstances.keys():
             # There are empty instances                
                 for instanceId, containerInstId in emptyInstances.iteritems():
                     if run == 'dry':


### PR DESCRIPTION
The logic used to determine future reservation values after a scale in action only takes into account the removal of a single instance. When there's more than one empty instance, we risk reducing the cluster reservation below the configured thresholds.